### PR TITLE
Add to lisp-imenu-generic-expression

### DIFF
--- a/iter2.el
+++ b/iter2.el
@@ -903,6 +903,8 @@ See `iter2-defun' for details."
 (when (and (fboundp 'iter-do) (null (get 'iter-do 'edebug-form-spec)))
   (put 'iter-do 'edebug-form-spec '((symbolp form) body)))
 
+(add-to-list 'lisp-imenu-generic-expression
+             (list nil (concat "^\\s-*(iter2-defun\\s-+\\(" lisp-mode-symbol-regexp "\\)") 1))
 
 (provide 'iter2)
 


### PR DESCRIPTION
So imenu can index iter2-defuns and iter2-lambdas